### PR TITLE
Make compatible with Gatsby V3

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto')
 
 exports.onCreateNode = (
-  { node, boundActionCreators, loadNodeContent },
+  { node, actions, loadNodeContent },
   pluginOptions
 ) => {
   if (!pluginOptions.name || pluginOptions.name !== node.sourceInstanceName) {
@@ -16,7 +16,7 @@ exports.onCreateNode = (
   }
 
   return loadNodeContent(node).then(content => {
-    const { createNode, createParentChildLink } = boundActionCreators
+    const { createNode, createParentChildLink } = actions
 
     const contentDigest = crypto
       .createHash('md5')


### PR DESCRIPTION
This package is currently broken on Gatsby V3.  Update `boundActionCreators` to `actions` to make package work with Gatsby V3.